### PR TITLE
Add poison effect and poisoned dagger

### DIFF
--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -13,10 +13,12 @@ impl Plugin for EffectsPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(
             FixedUpdate,
-            (burn::tick_burning,).run_if(in_state(GameState::Fight)),
+            (burn::tick_burning, poison::tick_poisoned,).run_if(in_state(GameState::Fight)),
         )
+        .add_event::<poison::PoisonEvent>()
         .add_observer(attack::on_attack)
         .add_observer(burn::on_burned)
-        .add_observer(shield::on_shield);
+        .add_observer(shield::on_shield)
+        .add_observer(poison::on_poisoned);
     }
 }

--- a/src/effects/poison.rs
+++ b/src/effects/poison.rs
@@ -1,4 +1,116 @@
-use bevy::prelude::Component;
+use crate::characters::{Character, Health};
+use crate::fighting::Battle;
+use bevy::prelude::*;
+use std::time::Duration;
 
-#[derive(Default, Component)]
-pub struct Poisoned;
+#[derive(Component)]
+pub struct Poison(u32);
+
+impl Poison {
+    pub fn new(amount: u32) -> Self {
+        Poison(amount)
+    }
+}
+
+#[derive(Event)]
+pub struct PoisonEvent {
+    attacker: Entity,
+    defender: Entity,
+    with: Entity,
+}
+
+impl PoisonEvent {
+    pub fn new(attacker: Entity, defender: Entity, with: Entity) -> Self {
+        Self {
+            attacker,
+            defender,
+            with,
+        }
+    }
+}
+
+#[derive(Component)]
+pub struct Poisoned {
+    amount: u32,
+    timer: Timer,
+}
+
+impl Poisoned {
+    pub fn new(amount: u32) -> Self {
+        Self {
+            amount,
+            timer: Timer::new(Duration::from_secs(1), TimerMode::Repeating),
+        }
+    }
+}
+
+pub fn tick_poisoned(
+    time: Res<Time>,
+    battle: Res<Battle>,
+    mut q_poisoned: Query<(Entity, &Name, &mut Poisoned, &mut Health)>,
+    mut commands: Commands,
+) {
+    q_poisoned
+        .iter_mut()
+        .for_each(|(entity, name, mut poisoned, mut health)| {
+            poisoned.timer.tick(time.delta());
+            
+            if !poisoned.timer.just_finished() {
+                return;
+            }
+
+            let poison_amt = poisoned.amount;
+            if poison_amt == 0 {
+                commands.entity(entity).remove::<Poisoned>();
+                return;
+            }
+
+            eprintln!(
+                "{:?}: Poisoned {:?} for {}",
+                battle.elapsed(time.elapsed_secs_f64()),
+                name,
+                poison_amt,
+            );
+
+            // Poison directly affects health, bypassing shields
+            health.current = health.current.saturating_sub(poison_amt);
+        });
+}
+
+pub fn on_poisoned(
+    trigger: Trigger<PoisonEvent>,
+    time: Res<Time>,
+    battle: Res<Battle>,
+    q_attacker: Query<&Name>,
+    mut q_defender: Query<(&Name, Option<&mut Poisoned>), With<Character>>,
+    q_poisoner: Query<(&Poison, &Name)>,
+    mut commands: Commands,
+) {
+    let PoisonEvent {
+        attacker,
+        defender,
+        with,
+    } = trigger.event();
+    let (defender_name, maybe_poisoned) = q_defender
+        .get_mut(*defender)
+        .expect("defender should exist");
+    let attacker_name = q_attacker.get(*attacker).expect("attacker should exist");
+
+    let (poison, source_name) = q_poisoner.get(*with).expect("poison source should exist");
+
+    if let Some(mut poisoned) = maybe_poisoned {
+        poisoned.amount += poison.0;
+    } else {
+        // we need to add a new poisoned component to the defender
+        commands.entity(*defender).insert(Poisoned::new(poison.0));
+    }
+
+    eprintln!(
+        "{:?}: {:?} poisoned {:?} with {} for {}!",
+        battle.elapsed(time.elapsed_secs_f64()),
+        attacker_name,
+        defender_name,
+        source_name,
+        poison.0,
+    );
+}

--- a/src/items/armory.rs
+++ b/src/items/armory.rs
@@ -1,3 +1,4 @@
+use crate::effects::poison::Poison;
 use crate::items::usable::Usable;
 use crate::items::weapons::Weapon;
 use crate::items::Item;
@@ -56,6 +57,27 @@ impl GenericUsable {
             name: name.into(),
             item: Item,
             usable: Usable::with_cooldown(cooldown),
+        }
+    }
+}
+
+#[derive(Bundle)]
+pub struct PoisonedDagger {
+    pub name: Name,
+    pub item: Item,
+    pub usable: Usable,
+    pub weapon: Weapon,
+    pub poison: Poison,
+}
+
+impl Default for PoisonedDagger {
+    fn default() -> Self {
+        Self {
+            name: "Poisoned Dagger".into(),
+            item: Item,
+            usable: Usable::with_cooldown(Duration::from_secs(4)),
+            weapon: Weapon { damage: 3 },
+            poison: Poison::new(5),
         }
     }
 }

--- a/src/items/mod.rs
+++ b/src/items/mod.rs
@@ -1,4 +1,5 @@
 use crate::items::burner::burner_used;
+use crate::items::poisoner::poisoner_used;
 use crate::items::shielder::shielder_used;
 use bevy::prelude::*;
 use usable::tick_usable;
@@ -6,6 +7,7 @@ use weapons::weapon_used;
 
 pub mod armory;
 mod burner;
+mod poisoner;
 mod shielder;
 mod usable;
 pub mod weapons;
@@ -17,6 +19,7 @@ impl Plugin for ItemsPlugin {
         app.add_observer(tick_usable)
             .add_observer(weapon_used)
             .add_observer(burner_used)
+            .add_observer(poisoner_used)
             .add_observer(shielder_used);
     }
 }

--- a/src/items/poisoner.rs
+++ b/src/items/poisoner.rs
@@ -1,0 +1,20 @@
+use crate::effects::poison::{Poison, PoisonEvent};
+use crate::fighting::Battle;
+use crate::items::usable::UseEvent;
+use bevy::prelude::*;
+
+pub fn poisoner_used(
+    trigger: Trigger<UseEvent>,
+    query: Query<&Parent, With<Poison>>,
+    mut commands: Commands,
+    battle: Res<Battle>,
+) {
+    let poisoned_with = trigger.entity();
+    let Ok(parent) = query.get(poisoned_with) else {
+        return;
+    };
+
+    let attacker = parent.get();
+    let defender = battle.opponent(attacker);
+    commands.trigger_targets(PoisonEvent::new(attacker, defender, poisoned_with), defender);
+}

--- a/src/loading.rs
+++ b/src/loading.rs
@@ -52,10 +52,12 @@ fn load_characters(mut commands: Commands, mut next_state: ResMut<NextState<Game
             e.insert_if_new(Shield::new(10));
             e.id()
         };
+        let poisoned_dagger = commands.spawn(PoisonedDagger::default()).id();
         let mut items = Items::default();
         items.slots.extend(vec![
             Some(commands.spawn(HandAxe::default()).id()),
             Some(shield_talisman),
+            Some(poisoned_dagger),
         ]);
         let villain = commands
             .spawn((


### PR DESCRIPTION
## Summary
- Implemented `Poison` effect and `Poisoned` condition
- `Poison` effect adds/increases `Poisoned` condition to opponent
- Every second, poisoned characters lose health equal to poison amount
- Poison damage bypasses shields
- Unlike burning, poison is not decremented every tick
- Added poisoned dagger weapon to villain's inventory

## Test plan
- Run the game and observe the poison effect in action
- Poisoned character should take poison damage every second
- Poison damage should bypass shields
- Poison amount should accumulate when hit multiple times

🤖 Generated with Claude Code