### PR TITLE
Add healing effect and healing potion

### DIFF
--- a/src/effects/heal.rs
+++ b/src/effects/heal.rs
@@ -1,0 +1,86 @@
+use crate::characters::{Character, Health};
+use crate::effects::poison::Poisoned;
+use crate::fighting::Battle;
+use bevy::prelude::*;
+
+#[derive(Component)]
+pub struct Heal(pub u32);
+
+impl Heal {
+    pub fn new(amount: u32) -> Self {
+        Heal(amount)
+    }
+}
+
+#[derive(Event)]
+pub struct HealEvent {
+    target: Entity,
+    with: Entity,
+}
+
+impl HealEvent {
+    pub fn new(target: Entity, with: Entity) -> Self {
+        Self { target, with }
+    }
+}
+
+pub fn on_heal(
+    trigger: Trigger<HealEvent>,
+    time: Res<Time>,
+    battle: Res<Battle>,
+    mut q_target: Query<(Entity, &Name, &mut Health, Option<&mut Poisoned>), With<Character>>,
+    q_heal_source: Query<(&Heal, &Name)>,
+    mut commands: Commands,
+) {
+    let HealEvent { target, with } = trigger.event();
+    
+    let Ok((entity, target_name, mut health, maybe_poisoned)) = q_target.get_mut(*target) else {
+        return;
+    };
+    
+    let Ok((heal, source_name)) = q_heal_source.get(*with) else {
+        return;
+    };
+    
+    let heal_amount = heal.0;
+    
+    // Calculate how much we can actually heal
+    let healing_needed = health.max.saturating_sub(health.current);
+    let actual_healing = heal_amount.min(healing_needed);
+    
+    if actual_healing > 0 {
+        health.current += actual_healing;
+        
+        eprintln!(
+            "{:?}: {:?} healed for {} using {}!",
+            battle.elapsed(time.elapsed_secs_f64()),
+            target_name,
+            actual_healing,
+            source_name,
+        );
+    }
+    
+    // If the character is poisoned, remove 1 point of poison when healed
+    if let Some(mut poisoned) = maybe_poisoned {
+        if poisoned.amount > 0 {
+            poisoned.amount = poisoned.amount.saturating_sub(1);
+            
+            eprintln!(
+                "{:?}: Healing reduced poison by 1 for {:?}!",
+                battle.elapsed(time.elapsed_secs_f64()),
+                target_name,
+            );
+            
+            // If there's no more poison, remove the Poisoned component
+            if poisoned.amount == 0 {
+                commands.entity(entity).remove::<Poisoned>();
+                
+                eprintln!(
+                    "{:?}: {:?} is no longer poisoned!",
+                    battle.elapsed(time.elapsed_secs_f64()),
+                    target_name,
+                );
+            }
+        }
+    }
+}

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -3,6 +3,7 @@ use bevy::prelude::*;
 
 pub mod attack;
 pub mod burn;
+pub mod heal;
 pub mod poison;
 pub mod regen;
 pub mod shield;
@@ -16,9 +17,11 @@ impl Plugin for EffectsPlugin {
             (burn::tick_burning, poison::tick_poisoned,).run_if(in_state(GameState::Fight)),
         )
         .add_event::<poison::PoisonEvent>()
+        .add_event::<heal::HealEvent>()
         .add_observer(attack::on_attack)
         .add_observer(burn::on_burned)
         .add_observer(shield::on_shield)
-        .add_observer(poison::on_poisoned);
+        .add_observer(poison::on_poisoned)
+        .add_observer(heal::on_heal);
     }
 }

--- a/src/effects/poison.rs
+++ b/src/effects/poison.rs
@@ -31,7 +31,7 @@ impl PoisonEvent {
 
 #[derive(Component)]
 pub struct Poisoned {
-    amount: u32,
+    pub amount: u32,
     timer: Timer,
 }
 

--- a/src/items/armory.rs
+++ b/src/items/armory.rs
@@ -1,3 +1,4 @@
+use crate::effects::heal::Heal;
 use crate::effects::poison::Poison;
 use crate::items::usable::Usable;
 use crate::items::weapons::Weapon;
@@ -78,6 +79,25 @@ impl Default for PoisonedDagger {
             usable: Usable::with_cooldown(Duration::from_secs(4)),
             weapon: Weapon { damage: 3 },
             poison: Poison::new(5),
+        }
+    }
+}
+
+#[derive(Bundle)]
+pub struct HealingPotion {
+    pub name: Name,
+    pub item: Item,
+    pub usable: Usable,
+    pub heal: Heal,
+}
+
+impl Default for HealingPotion {
+    fn default() -> Self {
+        Self {
+            name: "Healing Potion".into(),
+            item: Item,
+            usable: Usable::with_cooldown(Duration::from_secs(5)),
+            heal: Heal::new(20),
         }
     }
 }

--- a/src/items/healer.rs
+++ b/src/items/healer.rs
@@ -1,0 +1,21 @@
+use crate::effects::heal::{Heal, HealEvent};
+use crate::items::usable::UseEvent;
+use bevy::prelude::*;
+
+pub fn healer_used(
+    trigger: Trigger<UseEvent>,
+    query: Query<&Parent, With<Heal>>,
+    mut commands: Commands,
+) {
+    let heal_with = trigger.entity();
+    let Ok(parent) = query.get(heal_with) else {
+        return;
+    };
+
+    // Get the character using the heal item 
+    // (unlike other items, healer heals the user, not the opponent)
+    let target = parent.get();
+    
+    // Trigger healing on the user themselves
+    commands.trigger_targets(HealEvent::new(target, heal_with), target);
+}

--- a/src/items/mod.rs
+++ b/src/items/mod.rs
@@ -1,4 +1,5 @@
 use crate::items::burner::burner_used;
+use crate::items::healer::healer_used;
 use crate::items::poisoner::poisoner_used;
 use crate::items::shielder::shielder_used;
 use bevy::prelude::*;
@@ -7,6 +8,7 @@ use weapons::weapon_used;
 
 pub mod armory;
 mod burner;
+mod healer;
 mod poisoner;
 mod shielder;
 mod usable;
@@ -20,7 +22,8 @@ impl Plugin for ItemsPlugin {
             .add_observer(weapon_used)
             .add_observer(burner_used)
             .add_observer(poisoner_used)
-            .add_observer(shielder_used);
+            .add_observer(shielder_used)
+            .add_observer(healer_used);
     }
 }
 

--- a/src/loading.rs
+++ b/src/loading.rs
@@ -23,11 +23,14 @@ fn load_characters(mut commands: Commands, mut next_state: ResMut<NextState<Game
             e.insert_if_new(Burn::new(15));
             e.id()
         };
+        
+        let healing_potion = commands.spawn(HealingPotion::default()).id();
 
         let mut items = Items::default();
         items.slots.extend(vec![
             Some(commands.spawn(HandAxe::default()).id()),
             Some(burning_great_sword),
+            Some(healing_potion),
         ]);
 
         let hero = commands
@@ -53,11 +56,13 @@ fn load_characters(mut commands: Commands, mut next_state: ResMut<NextState<Game
             e.id()
         };
         let poisoned_dagger = commands.spawn(PoisonedDagger::default()).id();
+        let healing_potion = commands.spawn(HealingPotion::default()).id();
         let mut items = Items::default();
         items.slots.extend(vec![
             Some(commands.spawn(HandAxe::default()).id()),
             Some(shield_talisman),
             Some(poisoned_dagger),
+            Some(healing_potion),
         ]);
         let villain = commands
             .spawn((


### PR DESCRIPTION
## Summary
- Implement `Heal` component and healing system that:
  - Restores health to a character up to their maximum
  - Reduces poison effects by 1 point when healing
  - Removes the Poisoned component if poison is reduced to 0
- Create a `HealingPotion` item that heals the user (not the opponent)
- Add the healing potion to both characters for testing

## Test plan
- Run the game with `cargo run` and observe the battle log
- Verify that both characters can use their healing potions
- Check that healing reduces poison effect if character is poisoned

🤖 Generated with Claude Code