### PR TITLE
Add item status effects: slow, haste, and freeze

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,7 @@ name = "bazaaro"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "rand",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+rand = "0.8.5"
 
 [dependencies.bevy]
 version = "0.15.3"

--- a/src/effects/freeze.rs
+++ b/src/effects/freeze.rs
@@ -47,6 +47,7 @@ impl Frozen {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn on_frozen(
     trigger: Trigger<FreezeEvent>,
     time: Res<Time>,

--- a/src/effects/freeze.rs
+++ b/src/effects/freeze.rs
@@ -1,0 +1,97 @@
+use bevy::prelude::*;
+use std::time::Duration;
+
+use crate::fighting::Battle;
+use crate::items::Item;
+
+#[derive(Component)]
+pub struct Freeze {
+    pub duration: Duration,
+}
+
+impl Freeze {
+    pub fn new(duration_secs: f32) -> Self {
+        Self {
+            duration: Duration::from_secs_f32(duration_secs),
+        }
+    }
+}
+
+#[derive(Event)]
+pub struct FreezeEvent {
+    pub source: Entity,
+    pub target: Entity,
+    pub with: Entity,
+}
+
+impl FreezeEvent {
+    pub fn new(source: Entity, target: Entity, with: Entity) -> Self {
+        Self {
+            source,
+            target,
+            with,
+        }
+    }
+}
+
+#[derive(Component)]
+pub struct Frozen {
+    pub timer: Timer,
+}
+
+impl Frozen {
+    pub fn new(duration: Duration) -> Self {
+        Self {
+            timer: Timer::new(duration, TimerMode::Once),
+        }
+    }
+}
+
+pub fn on_frozen(
+    trigger: Trigger<FreezeEvent>,
+    time: Res<Time>,
+    battle: Res<Battle>,
+    q_source: Query<&Name>,
+    q_target: Query<&Name, With<Item>>,
+    q_freeze: Query<(&Freeze, &Name)>,
+    mut q_frozen_items: Query<&mut Frozen>,
+    mut commands: Commands,
+) {
+    let FreezeEvent { source, target, with } = trigger.event();
+    
+    let source_name = q_source.get(*source).expect("source should exist");
+    let target_name = q_target.get(*target).expect("target should exist");
+    
+    let (freeze, item_name) = q_freeze.get(*with).expect("freeze source should exist");
+    
+    // If the target already has the Frozen component, extend its duration
+    match q_frozen_items.get_mut(*target) {
+        Ok(mut frozen) => {
+            let remaining = frozen.timer.remaining();
+            frozen.timer.set_duration(remaining + freeze.duration);
+            frozen.timer.reset();
+            
+            eprintln!(
+                "{:?}: {:?} applied additional freeze to {} with {}! Total duration: {:?}",
+                battle.elapsed(time.elapsed_secs_f64()),
+                source_name,
+                target_name,
+                item_name,
+                frozen.timer.duration(),
+            );
+        }
+        Err(_) => {
+            // Add a new Frozen component to the target item
+            commands.entity(*target).insert(Frozen::new(freeze.duration));
+            
+            eprintln!(
+                "{:?}: {:?} froze {} with {} for {:?}!",
+                battle.elapsed(time.elapsed_secs_f64()),
+                source_name,
+                target_name,
+                item_name,
+                freeze.duration,
+            );
+        }
+    }
+}

--- a/src/effects/haste.rs
+++ b/src/effects/haste.rs
@@ -47,6 +47,7 @@ impl Hastened {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn on_hastened(
     trigger: Trigger<HasteEvent>,
     time: Res<Time>,

--- a/src/effects/haste.rs
+++ b/src/effects/haste.rs
@@ -1,0 +1,97 @@
+use bevy::prelude::*;
+use std::time::Duration;
+
+use crate::fighting::Battle;
+use crate::items::Item;
+
+#[derive(Component)]
+pub struct Haste {
+    pub duration: Duration,
+}
+
+impl Haste {
+    pub fn new(duration_secs: f32) -> Self {
+        Self {
+            duration: Duration::from_secs_f32(duration_secs),
+        }
+    }
+}
+
+#[derive(Event)]
+pub struct HasteEvent {
+    pub source: Entity,
+    pub target: Entity,
+    pub with: Entity,
+}
+
+impl HasteEvent {
+    pub fn new(source: Entity, target: Entity, with: Entity) -> Self {
+        Self {
+            source,
+            target,
+            with,
+        }
+    }
+}
+
+#[derive(Component)]
+pub struct Hastened {
+    pub timer: Timer,
+}
+
+impl Hastened {
+    pub fn new(duration: Duration) -> Self {
+        Self {
+            timer: Timer::new(duration, TimerMode::Once),
+        }
+    }
+}
+
+pub fn on_hastened(
+    trigger: Trigger<HasteEvent>,
+    time: Res<Time>,
+    battle: Res<Battle>,
+    q_source: Query<&Name>,
+    q_target: Query<&Name, With<Item>>,
+    q_haste: Query<(&Haste, &Name)>,
+    mut q_hastened_items: Query<&mut Hastened>,
+    mut commands: Commands,
+) {
+    let HasteEvent { source, target, with } = trigger.event();
+    
+    let source_name = q_source.get(*source).expect("source should exist");
+    let target_name = q_target.get(*target).expect("target should exist");
+    
+    let (haste, item_name) = q_haste.get(*with).expect("haste source should exist");
+    
+    // If the target already has the Hastened component, extend its duration
+    match q_hastened_items.get_mut(*target) {
+        Ok(mut hastened) => {
+            let remaining = hastened.timer.remaining();
+            hastened.timer.set_duration(remaining + haste.duration);
+            hastened.timer.reset();
+            
+            eprintln!(
+                "{:?}: {:?} applied additional haste to {} with {}! Total duration: {:?}",
+                battle.elapsed(time.elapsed_secs_f64()),
+                source_name,
+                target_name,
+                item_name,
+                hastened.timer.duration(),
+            );
+        }
+        Err(_) => {
+            // Add a new Hastened component to the target item
+            commands.entity(*target).insert(Hastened::new(haste.duration));
+            
+            eprintln!(
+                "{:?}: {:?} hastened {} with {} for {:?}!",
+                battle.elapsed(time.elapsed_secs_f64()),
+                source_name,
+                target_name,
+                item_name,
+                haste.duration,
+            );
+        }
+    }
+}

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -3,10 +3,13 @@ use bevy::prelude::*;
 
 pub mod attack;
 pub mod burn;
+pub mod freeze;
+pub mod haste;
 pub mod heal;
 pub mod poison;
 pub mod regen;
 pub mod shield;
+pub mod slow;
 
 pub struct EffectsPlugin;
 
@@ -18,10 +21,16 @@ impl Plugin for EffectsPlugin {
         )
         .add_event::<poison::PoisonEvent>()
         .add_event::<heal::HealEvent>()
+        .add_event::<slow::SlowEvent>()
+        .add_event::<freeze::FreezeEvent>()
+        .add_event::<haste::HasteEvent>()
         .add_observer(attack::on_attack)
         .add_observer(burn::on_burned)
         .add_observer(shield::on_shield)
         .add_observer(poison::on_poisoned)
-        .add_observer(heal::on_heal);
+        .add_observer(heal::on_heal)
+        .add_observer(slow::on_slowed)
+        .add_observer(freeze::on_frozen)
+        .add_observer(haste::on_hastened);
     }
 }

--- a/src/effects/slow.rs
+++ b/src/effects/slow.rs
@@ -47,6 +47,7 @@ impl Slowed {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn on_slowed(
     trigger: Trigger<SlowEvent>,
     time: Res<Time>,

--- a/src/effects/slow.rs
+++ b/src/effects/slow.rs
@@ -1,0 +1,97 @@
+use bevy::prelude::*;
+use std::time::Duration;
+
+use crate::fighting::Battle;
+use crate::items::Item;
+
+#[derive(Component)]
+pub struct Slow {
+    pub duration: Duration,
+}
+
+impl Slow {
+    pub fn new(duration_secs: f32) -> Self {
+        Self {
+            duration: Duration::from_secs_f32(duration_secs),
+        }
+    }
+}
+
+#[derive(Event)]
+pub struct SlowEvent {
+    pub source: Entity,
+    pub target: Entity,
+    pub with: Entity,
+}
+
+impl SlowEvent {
+    pub fn new(source: Entity, target: Entity, with: Entity) -> Self {
+        Self {
+            source,
+            target,
+            with,
+        }
+    }
+}
+
+#[derive(Component)]
+pub struct Slowed {
+    pub timer: Timer,
+}
+
+impl Slowed {
+    pub fn new(duration: Duration) -> Self {
+        Self {
+            timer: Timer::new(duration, TimerMode::Once),
+        }
+    }
+}
+
+pub fn on_slowed(
+    trigger: Trigger<SlowEvent>,
+    time: Res<Time>,
+    battle: Res<Battle>,
+    q_source: Query<&Name>,
+    q_target: Query<&Name, With<Item>>,
+    q_slow: Query<(&Slow, &Name)>,
+    mut q_slowed_items: Query<&mut Slowed>,
+    mut commands: Commands,
+) {
+    let SlowEvent { source, target, with } = trigger.event();
+    
+    let source_name = q_source.get(*source).expect("source should exist");
+    let target_name = q_target.get(*target).expect("target should exist");
+    
+    let (slow, item_name) = q_slow.get(*with).expect("slow source should exist");
+    
+    // If the target already has the Slowed component, extend its duration
+    match q_slowed_items.get_mut(*target) {
+        Ok(mut slowed) => {
+            let remaining = slowed.timer.remaining();
+            slowed.timer.set_duration(remaining + slow.duration);
+            slowed.timer.reset();
+            
+            eprintln!(
+                "{:?}: {:?} applied additional slow to {} with {}! Total duration: {:?}",
+                battle.elapsed(time.elapsed_secs_f64()),
+                source_name,
+                target_name,
+                item_name,
+                slowed.timer.duration(),
+            );
+        }
+        Err(_) => {
+            // Add a new Slowed component to the target item
+            commands.entity(*target).insert(Slowed::new(slow.duration));
+            
+            eprintln!(
+                "{:?}: {:?} slowed {} with {} for {:?}!",
+                battle.elapsed(time.elapsed_secs_f64()),
+                source_name,
+                target_name,
+                item_name,
+                slow.duration,
+            );
+        }
+    }
+}

--- a/src/items/armory.rs
+++ b/src/items/armory.rs
@@ -1,5 +1,11 @@
+use crate::effects::freeze::Freeze;
+use crate::effects::haste::Haste;
 use crate::effects::heal::Heal;
 use crate::effects::poison::Poison;
+use crate::effects::slow::Slow;
+use crate::items::freezer::Freezer;
+use crate::items::hastener::Hastener;
+use crate::items::slower::Slower;
 use crate::items::usable::Usable;
 use crate::items::weapons::Weapon;
 use crate::items::Item;
@@ -98,6 +104,69 @@ impl Default for HealingPotion {
             item: Item,
             usable: Usable::with_cooldown(Duration::from_secs(5)),
             heal: Heal::new(20),
+        }
+    }
+}
+
+#[derive(Bundle)]
+pub struct GorgonsHead {
+    pub name: Name,
+    pub item: Item,
+    pub usable: Usable,
+    pub slow: Slow,
+    pub slower: Slower,
+}
+
+impl Default for GorgonsHead {
+    fn default() -> Self {
+        Self {
+            name: "Gorgon's Head".into(),
+            item: Item,
+            usable: Usable::with_cooldown(Duration::from_secs(2)),
+            slow: Slow::new(1.0), // Slows for 1 second
+            slower: Slower,
+        }
+    }
+}
+
+#[derive(Bundle)]
+pub struct FreezingCrystal {
+    pub name: Name,
+    pub item: Item,
+    pub usable: Usable,
+    pub freeze: Freeze,
+    pub freezer: Freezer,
+}
+
+impl Default for FreezingCrystal {
+    fn default() -> Self {
+        Self {
+            name: "Freezing Crystal".into(),
+            item: Item,
+            usable: Usable::with_cooldown(Duration::from_secs(3)),
+            freeze: Freeze::new(1.5), // Freezes for 1.5 seconds
+            freezer: Freezer,
+        }
+    }
+}
+
+#[derive(Bundle)]
+pub struct HastePotion {
+    pub name: Name,
+    pub item: Item,
+    pub usable: Usable,
+    pub haste: Haste,
+    pub hastener: Hastener,
+}
+
+impl Default for HastePotion {
+    fn default() -> Self {
+        Self {
+            name: "Haste Potion".into(),
+            item: Item,
+            usable: Usable::with_cooldown(Duration::from_secs(4)),
+            haste: Haste::new(2.0), // Hastens for 2 seconds
+            hastener: Hastener,
         }
     }
 }

--- a/src/items/freezer.rs
+++ b/src/items/freezer.rs
@@ -1,0 +1,59 @@
+use bevy::prelude::*;
+use rand::prelude::*;
+
+use crate::characters::{Character, Items};
+use crate::effects::freeze::FreezeEvent;
+use crate::fighting::Battle;
+use crate::items::usable::UseEvent;
+
+#[derive(Component)]
+pub struct Freezer;
+
+pub fn freezer_used(
+    trigger: Trigger<UseEvent>,
+    battle: Res<Battle>,
+    q_character: Query<(Entity, &Items), With<Character>>,
+    q_freezer: Query<(Entity, &Parent), With<Freezer>>,
+    mut commands: Commands,
+) {
+    // The entity that triggered the event
+    let freezer_entity = trigger.entity();
+
+    // Only continue if the item has the Freezer component
+    let (freezer_entity, parent) = match q_freezer.get(freezer_entity) {
+        Ok(result) => result,
+        Err(_) => return,
+    };
+
+    // Find the owner of this item
+    let source_entity = parent.get();
+    
+    // Find the opponent using the battle resource
+    let opponent_entity = battle.opponent(source_entity);
+
+    // Now we need to find a random item in the opponent's inventory
+    let (_, opponent_items) = match q_character.get(opponent_entity) {
+        Ok(result) => result,
+        Err(_) => return,
+    };
+
+    // Collect all non-empty slots
+    let available_items: Vec<Entity> = opponent_items
+        .slots
+        .iter()
+        .filter_map(|slot| slot.as_ref().copied())
+        .collect();
+
+    // If there are no items, return early
+    if available_items.is_empty() {
+        return;
+    }
+
+    // Pick a random item from the available items
+    let mut rng = thread_rng();
+    let random_index = rng.gen_range(0..available_items.len());
+    let target_item = available_items[random_index];
+
+    // Trigger the freeze event
+    commands.trigger(FreezeEvent::new(source_entity, target_item, freezer_entity));
+}

--- a/src/items/hastener.rs
+++ b/src/items/hastener.rs
@@ -1,0 +1,47 @@
+use bevy::prelude::*;
+
+use crate::characters::{Character, Items};
+use crate::effects::haste::HasteEvent;
+use crate::items::usable::UseEvent;
+
+#[derive(Component)]
+pub struct Hastener;
+
+pub fn hastener_used(
+    trigger: Trigger<UseEvent>,
+    q_character: Query<(Entity, &Items), With<Character>>,
+    q_hastener: Query<(Entity, &Parent), With<Hastener>>,
+    mut commands: Commands,
+) {
+    // The entity that triggered the event
+    let hastener_entity = trigger.entity();
+
+    // Only continue if the item has the Hastener component
+    let (hastener_entity, parent) = match q_hastener.get(hastener_entity) {
+        Ok(result) => result,
+        Err(_) => return,
+    };
+
+    // Find the owner of this item
+    let source_entity = parent.get();
+
+    // The Haste Potion targets a friendly item (our own item)
+    // We'll pick the leftmost item (which is usually a weapon) to make it more useful
+    let (_, owner_items) = match q_character.get(source_entity) {
+        Ok(result) => result,
+        Err(_) => return,
+    };
+
+    // Get the leftmost non-empty slot (but not the haste potion itself)
+    let target_item = owner_items
+        .slots
+        .iter()
+        .filter_map(|slot| slot.as_ref().copied())
+        .filter(|item| *item != hastener_entity) // Don't target self
+        .next();
+
+    // If we found a target item, trigger the haste event
+    if let Some(target_item) = target_item {
+        commands.trigger(HasteEvent::new(source_entity, target_item, hastener_entity));
+    }
+}

--- a/src/items/hastener.rs
+++ b/src/items/hastener.rs
@@ -36,9 +36,7 @@ pub fn hastener_used(
     let target_item = owner_items
         .slots
         .iter()
-        .filter_map(|slot| slot.as_ref().copied())
-        .filter(|item| *item != hastener_entity) // Don't target self
-        .next();
+        .filter_map(|slot| slot.as_ref().copied()).find(|item| *item != hastener_entity);
 
     // If we found a target item, trigger the haste event
     if let Some(target_item) = target_item {

--- a/src/items/mod.rs
+++ b/src/items/mod.rs
@@ -1,17 +1,23 @@
 use crate::items::burner::burner_used;
+use crate::items::freezer::freezer_used;
+use crate::items::hastener::hastener_used;
 use crate::items::healer::healer_used;
 use crate::items::poisoner::poisoner_used;
 use crate::items::shielder::shielder_used;
+use crate::items::slower::slower_used;
 use bevy::prelude::*;
 use usable::tick_usable;
 use weapons::weapon_used;
 
 pub mod armory;
 mod burner;
+mod freezer;
+mod hastener;
 mod healer;
 mod poisoner;
 mod shielder;
-mod usable;
+mod slower;
+pub mod usable;
 pub mod weapons;
 
 pub struct ItemsPlugin;
@@ -23,7 +29,10 @@ impl Plugin for ItemsPlugin {
             .add_observer(burner_used)
             .add_observer(poisoner_used)
             .add_observer(shielder_used)
-            .add_observer(healer_used);
+            .add_observer(healer_used)
+            .add_observer(slower_used)
+            .add_observer(freezer_used)
+            .add_observer(hastener_used);
     }
 }
 

--- a/src/items/slower.rs
+++ b/src/items/slower.rs
@@ -1,0 +1,51 @@
+use bevy::prelude::*;
+
+use crate::characters::{Character, Items};
+use crate::effects::slow::SlowEvent;
+use crate::fighting::Battle;
+use crate::items::usable::UseEvent;
+
+#[derive(Component)]
+pub struct Slower;
+
+pub fn slower_used(
+    trigger: Trigger<UseEvent>,
+    battle: Res<Battle>,
+    q_character: Query<(Entity, &Items), With<Character>>,
+    q_slower: Query<(Entity, &Parent), With<Slower>>,
+    mut commands: Commands,
+) {
+    // The entity that triggered the event
+    let slower_entity = trigger.entity();
+
+    // Only continue if the item has the Slower component
+    let (slower_entity, parent) = match q_slower.get(slower_entity) {
+        Ok(result) => result,
+        Err(_) => return,
+    };
+
+    // Find the owner of this item
+    let source_entity = parent.get();
+    
+    // Find the opponent using the battle resource
+    let opponent_entity = battle.opponent(source_entity);
+
+    // Now we need to find the rightmost item in the opponent's inventory
+    let (_, opponent_items) = match q_character.get(opponent_entity) {
+        Ok(result) => result,
+        Err(_) => return,
+    };
+
+    // Get the rightmost non-empty slot
+    let target_item = opponent_items
+        .slots
+        .iter()
+        .rev() // Start from the right
+        .filter_map(|slot| slot.as_ref().copied())
+        .next();
+
+    // If we found a target item, trigger the slow event
+    if let Some(target_item) = target_item {
+        commands.trigger(SlowEvent::new(source_entity, target_item, slower_entity));
+    }
+}

--- a/src/items/usable.rs
+++ b/src/items/usable.rs
@@ -1,22 +1,94 @@
+use crate::effects::freeze::Frozen;
+use crate::effects::haste::Hastened;
+use crate::effects::slow::Slowed;
 use crate::fighting::TickEvent;
 use bevy::prelude::*;
 use std::time::Duration;
 
 pub fn tick_usable(
-    _: Trigger<TickEvent>,
+    _trigger: Trigger<TickEvent>,
+    _time: Res<Time>,
     mut q_usable: Query<(&mut Usable, Entity)>,
+    mut q_hastened: Query<(Entity, &mut Hastened)>,
+    mut q_slowed: Query<(Entity, &mut Slowed)>,
+    mut q_frozen: Query<(Entity, &mut Frozen)>,
     mut commands: Commands,
 ) {
+    // First, tick all condition timers
+    let mut entities_to_unfreeze = Vec::new();
+    let mut entities_to_unhaste = Vec::new();
+    let mut entities_to_unslow = Vec::new();
+    
+    for (entity, mut frozen) in q_frozen.iter_mut() {
+        frozen.timer.tick(Duration::from_millis(100));
+        if frozen.timer.just_finished() {
+            eprintln!("Frozen condition expired on {:?}", entity);
+            entities_to_unfreeze.push(entity);
+        }
+    }
+    
+    for (entity, mut hastened) in q_hastened.iter_mut() {
+        hastened.timer.tick(Duration::from_millis(100));
+        if hastened.timer.just_finished() {
+            eprintln!("Hastened condition expired on {:?}", entity);
+            entities_to_unhaste.push(entity);
+        }
+    }
+    
+    for (entity, mut slowed) in q_slowed.iter_mut() {
+        slowed.timer.tick(Duration::from_millis(100));
+        if slowed.timer.just_finished() {
+            eprintln!("Slowed condition expired on {:?}", entity);
+            entities_to_unslow.push(entity);
+        }
+    }
+
+    // Then process the usable items
     q_usable.iter_mut().for_each(|(mut usable, entity)| {
         let timer = &mut usable.cooldown;
-        // TODO: haste/slow/freeze here
-        timer.tick(Duration::from_millis(100));
+        
+        // Check for conditions
+        let is_frozen = q_frozen.contains(entity);
+        let is_hastened = q_hastened.contains(entity);
+        let is_slowed = q_slowed.contains(entity);
+        
+        // Apply the appropriate tick duration based on conditions
+        if is_frozen {
+            // Frozen items don't tick their cooldown
+            // Do nothing here
+        } else if is_hastened && is_slowed {
+            // If both hastened and slowed, they cancel out
+            timer.tick(Duration::from_millis(100));
+        } else if is_hastened {
+            // Hastened items tick at double speed (200ms instead of 100ms)
+            timer.tick(Duration::from_millis(200));
+        } else if is_slowed {
+            // Slowed items tick at half speed (50ms instead of 100ms)
+            timer.tick(Duration::from_millis(50));
+        } else {
+            // Normal tick speed
+            timer.tick(Duration::from_millis(100));
+        }
+        
         if timer.just_finished() {
             commands.trigger_targets(UseEvent {}, entity);
             // reset the cooldown
             usable.cooldown = Timer::new(timer.duration(), TimerMode::Once);
         }
     });
+    
+    // Remove expired conditions at the end
+    for entity in entities_to_unfreeze {
+        commands.entity(entity).remove::<Frozen>();
+    }
+    
+    for entity in entities_to_unhaste {
+        commands.entity(entity).remove::<Hastened>();
+    }
+    
+    for entity in entities_to_unslow {
+        commands.entity(entity).remove::<Slowed>();
+    }
 }
 
 #[derive(Component)]

--- a/src/loading.rs
+++ b/src/loading.rs
@@ -25,12 +25,18 @@ fn load_characters(mut commands: Commands, mut next_state: ResMut<NextState<Game
         };
         
         let healing_potion = commands.spawn(HealingPotion::default()).id();
+        let gorgons_head = commands.spawn(GorgonsHead::default()).id();
+        let freezing_crystal = commands.spawn(FreezingCrystal::default()).id();
+        let haste_potion = commands.spawn(HastePotion::default()).id();
 
         let mut items = Items::default();
         items.slots.extend(vec![
             Some(commands.spawn(HandAxe::default()).id()),
             Some(burning_great_sword),
             Some(healing_potion),
+            Some(gorgons_head),
+            Some(freezing_crystal),
+            Some(haste_potion),
         ]);
 
         let hero = commands


### PR DESCRIPTION
## Summary
- Added three new item status effects (slow, haste, freeze) that modify cooldown speeds
- Implemented three new items that apply these effects: Gorgon's Head, Freezing Crystal, and Haste Potion
- Refactored usable item system to support conditional cooldown rates

## Test plan
- Run the game to confirm status effects are properly applied and removed
- Verify cooldown speeds behave correctly (half speed for slow, double speed for haste, no ticking for freeze)
- Check that effects properly expire after their duration

🤖 Generated with [Claude Code](https://claude.ai/code)